### PR TITLE
Determine `database_url` when first accessed versus when required

### DIFF
--- a/src/micrate/db.cr
+++ b/src/micrate/db.cr
@@ -3,11 +3,7 @@ require "./db/*"
 
 module Micrate
   module DB
-    @@connection_url = ENV["DATABASE_URL"]?
-
-    def self.connection_url
-      @@connection_url
-    end
+    class_getter connection_url : String? { ENV["DATABASE_URL"]? }
 
     def self.connection_url=(connection_url)
       @@dialect = nil
@@ -16,12 +12,12 @@ module Micrate
 
     def self.connect
       validate_connection_url
-      ::DB.connect(@@connection_url.not_nil!)
+      ::DB.connect(self.connection_url.not_nil!)
     end
 
     def self.connect(&block)
       validate_connection_url
-      ::DB.open @@connection_url.not_nil! do |db|
+      ::DB.open self.connection_url.not_nil! do |db|
         yield db
       end
     end
@@ -55,11 +51,11 @@ module Micrate
 
     private def self.dialect
       validate_connection_url
-      @@dialect ||= Dialect.from_connection_url(@@connection_url.not_nil!)
+      @@dialect ||= Dialect.from_connection_url(self.connection_url.not_nil!)
     end
 
     private def self.validate_connection_url
-      if !@@connection_url
+      if !self.connection_url
         raise "No database connection URL is configured. Please set the DATABASE_URL environment variable."
       end
     end


### PR DESCRIPTION
Changes how the `DATABASE_URL` ENV var is loaded so that the value is determined when first used instead of when micrate itself is required. Removes the need to manually overwrite the connection URL if the ENV var is not immediately available. E.g. when set via a dotenv shard.

Before: 
```cr
ENV["DATABASE_URL"] = "FOO"

require "./src/micrate"

ENV["DATABASE_URL"] = "BAR"

pp Micrate::DB.connection_url # => "FOO"
```

After:
```cr
ENV["DATABASE_URL"] = "FOO"

require "./src/micrate"

ENV["DATABASE_URL"] = "BAR"

pp Micrate::DB.connection_url # => "BAR"
```