### PR TITLE
Doesn't depend on all database backends.

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -11,7 +11,7 @@ maintainers:
 
 targets:
   micrate:
-    main: src/micrate-bin.cr
+    main: src/micrate-wrapper.cr
 
 scripts:
   postinstall: shards build
@@ -22,16 +22,6 @@ executables:
 dependencies:
   db:
     github: crystal-lang/crystal-db
-    version: ~> 0.11.0
-  pg:
-    github: will/crystal-pg
-    version: ~> 0.26.0
-  mysql:
-    github: crystal-lang/crystal-mysql
-    version: ~> 0.14.0
-  sqlite3:
-    github: crystal-lang/crystal-sqlite3
-    version: ~> 0.19.0
 
 development_dependencies:
   spectator:

--- a/src/micrate-cli.cr
+++ b/src/micrate-cli.cr
@@ -1,7 +1,9 @@
 require "log"
-require "pg"
-require "mysql"
-require "sqlite3"
+{% for db in %w(pg mysql sqlite3) %}
+  {% if file_exists?("lib/" + db) %}
+    require {{ db }}
+  {% end %}
+{% end %}
 
 require "./micrate"
 

--- a/src/micrate-wrapper.cr
+++ b/src/micrate-wrapper.cr
@@ -1,0 +1,25 @@
+require "colorize"
+
+VERSION = `shards version lib/micrate`.strip
+
+def micrate_executable
+  {% if flag?(:windows) %}
+    "bin/micrate-cli-#{VERSION}.exe"
+  {% else %}
+    "bin/micrate-cli-#{VERSION}"
+  {% end %}
+end
+
+exe_path = Process.executable_path
+abort("Failed to find micrate location") if exe_path.nil?
+
+Dir.cd("#{Path.new(exe_path).dirname}/..")
+
+unless File.exists?(micrate_executable)
+  puts "Compiling micrate CLI...".colorize.green
+  if !system("crystal build lib/micrate/src/micrate-cli.cr -o #{micrate_executable}")
+    abort("Failed to compile micrate CLI.".colorize.red)
+  end
+end
+
+Process.exec(micrate_executable, ARGV)


### PR DESCRIPTION
This works by having a wrapper that compiles the CLI on first use, when the database backend libraries were already downloaded by shards.
    
Changes:
- Rename src/micrate-bin.cr to src/micrate-cli.cr
- Add src/micrate-wrapper.cr that compiles in a post install to bin/micrate.
- bin/micrate compiles src/micrate-cli to bin/micrate-cli-<VERSION>
- src/micrate-cli.cr only require database backends found in lib/
- Do not pin crystal-db version to avoid having to release new micrate versions on every crystal-db release.

Fix #87

> [!CAUTION]
> Despite of the code dealing with windows I only tested this on Linux, would be nice if someone else test this (and possible fix it) on windows before merge.
